### PR TITLE
add explosion and commands upon entry denial flags

### DIFF
--- a/common/src/main/java/org/empirewar/orbis/flag/DefaultFlags.java
+++ b/common/src/main/java/org/empirewar/orbis/flag/DefaultFlags.java
@@ -103,8 +103,14 @@ public final class DefaultFlags {
             "A list of commands to be executed by the console upon entry", ArrayList::new, Codec.STRING.listOf());
     public static final RegistryRegionFlag<List<String>> EXIT_CONSOLE_COMMANDS = register("exit_console_commands",
             "A list of commands to be executed by the console upon exit", ArrayList::new, Codec.STRING.listOf());
+    public static final RegistryRegionFlag<List<String>> ENTRY_DENIED_COMMANDS = register("entry_denied_commands",
+            "A list of commands to be executed when a player's entry is denied", ArrayList::new, Codec.STRING.listOf());
     public static final RegistryRegionFlag<Boolean> CAN_GLIDE = register("can_glide",
             "Whether players can glide with elytra", () -> true, Codec.BOOL);
+    public static final RegistryRegionFlag<Boolean> CAN_ENTITIES_EXPLODE = register("can_entities_explode",
+            "Whether entity-caused explosions can break blocks", () -> true, Codec.BOOL);
+    public static final RegistryRegionFlag<Boolean> CAN_BLOCKS_EXPLODE = register("can_blocks_explode",
+            "Whether block-caused explosions can break blocks", () -> true, Codec.BOOL);
     // spotless:on
 
     private static <T> RegistryRegionFlag<T> register(

--- a/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/BlockActionListener.java
+++ b/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/BlockActionListener.java
@@ -34,10 +34,12 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockFadeEvent;
 import org.bukkit.event.block.BlockGrowEvent;
 import org.bukkit.event.block.BlockPistonEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.event.block.LeavesDecayEvent;
@@ -107,6 +109,13 @@ public record BlockActionListener(OrbisPaperPlatform<?> orbis) implements Listen
         }
     }
 
+    @EventHandler(ignoreCancelled = true)
+    public void onExplode(BlockExplodeEvent event) {
+        event.blockList()
+                .removeIf(
+                        block -> shouldPreventBlockAction(block, DefaultFlags.CAN_BLOCKS_EXPLODE));
+    }
+
     @EventHandler
     public void onFade(BlockFadeEvent event) {
         final Block block = event.getBlock();
@@ -166,7 +175,7 @@ public record BlockActionListener(OrbisPaperPlatform<?> orbis) implements Listen
     }
 
     @EventHandler
-    public void onPull(BlockPistonExtendEvent event) {
+    public void onPull(BlockPistonRetractEvent event) {
         this.handlePistonEvent(event, event.getBlocks());
     }
 

--- a/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/EntityListener.java
+++ b/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/EntityListener.java
@@ -220,7 +220,8 @@ public class EntityListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onEntityExplode(EntityExplodeEvent event) {
-        final RegionisedWorld world = orbis.getRegionisedWorld(event.getLocation().getWorld());
+        final RegionisedWorld world =
+                orbis.getRegionisedWorld(event.getLocation().getWorld());
         event.blockList().removeIf(block -> {
             return !world.query(RegionQuery.Position.at(block.getX(), block.getY(), block.getZ()))
                     .query(RegionQuery.Flag.builder(DefaultFlags.CAN_ENTITIES_EXPLODE))

--- a/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/EntityListener.java
+++ b/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/EntityListener.java
@@ -29,7 +29,6 @@ import io.papermc.paper.event.player.PrePlayerAttackEntityEvent;
 import net.kyori.adventure.key.Key;
 
 import org.bukkit.Location;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Painting;
@@ -221,17 +220,12 @@ public class EntityListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onEntityExplode(EntityExplodeEvent event) {
-        // Check if the explosion is allowed to break blocks in the region
-        event.blockList().removeIf(this::shouldPreventEntityExplosionAt);
-    }
-
-    private boolean shouldPreventEntityExplosionAt(Block block) {
-        final RegionisedWorld world = orbis.getRegionisedWorld(block.getWorld());
-        final boolean canExplode = world.query(
-                        RegionQuery.Position.at(block.getX(), block.getY(), block.getZ()))
-                .query(RegionQuery.Flag.builder(DefaultFlags.CAN_ENTITIES_EXPLODE))
-                .result()
-                .orElse(true);
-        return !canExplode;
+        final RegionisedWorld world = orbis.getRegionisedWorld(event.getLocation().getWorld());
+        event.blockList().removeIf(block -> {
+            return !world.query(RegionQuery.Position.at(block.getX(), block.getY(), block.getZ()))
+                    .query(RegionQuery.Flag.builder(DefaultFlags.CAN_ENTITIES_EXPLODE))
+                    .result()
+                    .orElse(true);
+        });
     }
 }

--- a/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/EntityListener.java
+++ b/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/EntityListener.java
@@ -29,6 +29,7 @@ import io.papermc.paper.event.player.PrePlayerAttackEntityEvent;
 import net.kyori.adventure.key.Key;
 
 import org.bukkit.Location;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Painting;
@@ -38,6 +39,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -215,5 +217,21 @@ public class EntityListener implements Listener {
                 event.setCancelled(true);
             }
         }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onEntityExplode(EntityExplodeEvent event) {
+        // Check if the explosion is allowed to break blocks in the region
+        event.blockList().removeIf(this::shouldPreventEntityExplosionAt);
+    }
+
+    private boolean shouldPreventEntityExplosionAt(Block block) {
+        final RegionisedWorld world = orbis.getRegionisedWorld(block.getWorld());
+        final boolean canExplode = world.query(
+                        RegionQuery.Position.at(block.getX(), block.getY(), block.getZ()))
+                .query(RegionQuery.Flag.builder(DefaultFlags.CAN_ENTITIES_EXPLODE))
+                .result()
+                .orElse(true);
+        return !canExplode;
     }
 }

--- a/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/MovementListener.java
+++ b/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/MovementListener.java
@@ -41,9 +41,19 @@ import org.empirewar.orbis.query.RegionQuery;
 import org.empirewar.orbis.region.Region;
 import org.empirewar.orbis.world.RegionisedWorld;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
-public record MovementListener(OrbisPaperPlatform<?> orbis) implements Listener {
+public class MovementListener implements Listener {
+    private final OrbisPaperPlatform<?> orbis;
+    private static final long DENY_COOLDOWN_MS = 3000L;
+    private final Map<UUID, Long> denialCooldowns = new HashMap<>();
+
+    public MovementListener(OrbisPaperPlatform<?> orbis) {
+        this.orbis = orbis;
+    }
 
     @EventHandler
     public void onMove(PlayerMoveEvent event) {
@@ -61,6 +71,19 @@ public record MovementListener(OrbisPaperPlatform<?> orbis) implements Listener 
                 .orElse(true);
 
         if (!canMove) {
+            long now = System.currentTimeMillis();
+            long lastDenied = denialCooldowns.getOrDefault(player.getUniqueId(), 0L);
+            if (now - lastDenied >= DENY_COOLDOWN_MS) {
+                denialCooldowns.put(player.getUniqueId(), now);
+
+                toQuery.query(RegionQuery.Flag.builder(DefaultFlags.ENTRY_DENIED_COMMANDS)
+                                .player(player.getUniqueId()))
+                        .result()
+                        .ifPresent(commands -> commands.forEach(cmd -> Bukkit.dispatchCommand(
+                                Bukkit.getConsoleSender(),
+                                cmd.replace("%player%", player.getName())
+                                        .replace("%uuid%", player.getUniqueId().toString()))));
+            }
             event.setTo(new Location(
                     from.getWorld(),
                     from.getX(),
@@ -112,6 +135,21 @@ public record MovementListener(OrbisPaperPlatform<?> orbis) implements Listener 
                 .orElse(true);
         if (!canMove) {
             event.setCancelled(true);
+            long now = System.currentTimeMillis();
+            long lastDenied = denialCooldowns.getOrDefault(player.getUniqueId(), 0L);
+            if (now - lastDenied >= DENY_COOLDOWN_MS) {
+                denialCooldowns.put(player.getUniqueId(), now);
+                world.query(RegionQuery.Position.builder()
+                                .position(to.getX(), to.getY(), to.getZ())
+                                .build())
+                        .query(RegionQuery.Flag.builder(DefaultFlags.ENTRY_DENIED_COMMANDS)
+                                .player(player.getUniqueId()))
+                        .result()
+                        .ifPresent(commands -> commands.forEach(cmd -> Bukkit.dispatchCommand(
+                                Bukkit.getConsoleSender(),
+                                cmd.replace("%player%", player.getName())
+                                        .replace("%uuid%", player.getUniqueId().toString()))));
+            }
         }
     }
 

--- a/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/MovementListener.java
+++ b/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/MovementListener.java
@@ -59,7 +59,7 @@ public class MovementListener implements Listener {
     public void onMove(PlayerMoveEvent event) {
         final Location to = event.getTo();
         final Location from = event.getFrom();
-        if (to == null || to.distanceSquared(from) == 0) return;
+        if (to == null || from.getBlock().equals(to.getBlock())) return;
 
         final Player player = event.getPlayer();
         final RegionisedWorld world = orbis.getRegionisedWorld(to.getWorld());

--- a/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/MovementListener.java
+++ b/platforms/paper/src/main/java/org/empirewar/orbis/paper/listener/MovementListener.java
@@ -25,6 +25,7 @@ package org.empirewar.orbis.paper.listener;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -33,6 +34,7 @@ import org.bukkit.event.entity.EntityToggleGlideEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.persistence.PersistentDataType;
 import org.empirewar.orbis.flag.DefaultFlags;
 import org.empirewar.orbis.paper.OrbisPaperPlatform;
 import org.empirewar.orbis.paper.api.event.RegionEnterEvent;
@@ -41,15 +43,13 @@ import org.empirewar.orbis.query.RegionQuery;
 import org.empirewar.orbis.region.Region;
 import org.empirewar.orbis.world.RegionisedWorld;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 public class MovementListener implements Listener {
     private final OrbisPaperPlatform<?> orbis;
     private static final long DENY_COOLDOWN_MS = 3000L;
-    private final Map<UUID, Long> denialCooldowns = new HashMap<>();
+    private static final NamespacedKey ENTRY_DENY_COOLDOWN_KEY =
+            new NamespacedKey("orbis", "entry_deny_cooldown");
 
     public MovementListener(OrbisPaperPlatform<?> orbis) {
         this.orbis = orbis;
@@ -71,19 +71,7 @@ public class MovementListener implements Listener {
                 .orElse(true);
 
         if (!canMove) {
-            long now = System.currentTimeMillis();
-            long lastDenied = denialCooldowns.getOrDefault(player.getUniqueId(), 0L);
-            if (now - lastDenied >= DENY_COOLDOWN_MS) {
-                denialCooldowns.put(player.getUniqueId(), now);
-
-                toQuery.query(RegionQuery.Flag.builder(DefaultFlags.ENTRY_DENIED_COMMANDS)
-                                .player(player.getUniqueId()))
-                        .result()
-                        .ifPresent(commands -> commands.forEach(cmd -> Bukkit.dispatchCommand(
-                                Bukkit.getConsoleSender(),
-                                cmd.replace("%player%", player.getName())
-                                        .replace("%uuid%", player.getUniqueId().toString()))));
-            }
+            handleEntryDenial(player, toQuery);
             event.setTo(new Location(
                     from.getWorld(),
                     from.getX(),
@@ -127,29 +115,36 @@ public class MovementListener implements Listener {
         final Player player = event.getPlayer();
         final Location to = event.getTo();
         final RegionisedWorld world = orbis.getRegionisedWorld(to.getWorld());
-        final boolean canMove = world.query(
-                        RegionQuery.Position.builder().position(to.getX(), to.getY(), to.getZ()))
+        var queryResult = world.query(RegionQuery.Position.at(to.getX(), to.getY(), to.getZ()));
+        boolean canMove = queryResult
                 .query(RegionQuery.Flag.builder(DefaultFlags.CAN_ENTER)
                         .player(player.getUniqueId()))
                 .result()
                 .orElse(true);
         if (!canMove) {
             event.setCancelled(true);
-            long now = System.currentTimeMillis();
-            long lastDenied = denialCooldowns.getOrDefault(player.getUniqueId(), 0L);
-            if (now - lastDenied >= DENY_COOLDOWN_MS) {
-                denialCooldowns.put(player.getUniqueId(), now);
-                world.query(RegionQuery.Position.builder()
-                                .position(to.getX(), to.getY(), to.getZ())
-                                .build())
-                        .query(RegionQuery.Flag.builder(DefaultFlags.ENTRY_DENIED_COMMANDS)
-                                .player(player.getUniqueId()))
-                        .result()
-                        .ifPresent(commands -> commands.forEach(cmd -> Bukkit.dispatchCommand(
-                                Bukkit.getConsoleSender(),
-                                cmd.replace("%player%", player.getName())
-                                        .replace("%uuid%", player.getUniqueId().toString()))));
-            }
+            handleEntryDenial(player, queryResult);
+        }
+    }
+
+    private void handleEntryDenial(
+            Player player, RegionQuery.FilterableRegionResult<?> queryResult) {
+        long lastDenied = player.getPersistentDataContainer()
+                .getOrDefault(ENTRY_DENY_COOLDOWN_KEY, PersistentDataType.LONG, 0L);
+        if (System.currentTimeMillis() - lastDenied >= DENY_COOLDOWN_MS) {
+            player.getPersistentDataContainer()
+                    .set(
+                            ENTRY_DENY_COOLDOWN_KEY,
+                            PersistentDataType.LONG,
+                            System.currentTimeMillis());
+            queryResult
+                    .query(RegionQuery.Flag.builder(DefaultFlags.ENTRY_DENIED_COMMANDS)
+                            .player(player.getUniqueId()))
+                    .result()
+                    .ifPresent(commands -> commands.forEach(cmd -> Bukkit.dispatchCommand(
+                            Bukkit.getConsoleSender(),
+                            cmd.replace("%player%", player.getName())
+                                    .replace("%uuid%", player.getUniqueId().toString()))));
         }
     }
 


### PR DESCRIPTION
* Adds `ENTRY_DENIED_COMMANDS` with a 3s cooldown (PDC-based).
* Adds `CAN_ENTITIES_EXPLODE` and `CAN_BLOCKS_EXPLODE`.
* Fixed `onPull` using `BlockPistonExtendEvent` instead of `BlockPistonRetractEvent`.
* Optimized some movement queries.

I'm not quite sure how to better go about the cooldown stuff for this plugin, to be honest. Let me know if you have any questions/concerns.